### PR TITLE
Support python3.10 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
+          - 3.9  // Mypy doens't yet work with python 3.10
 
     steps:
       - uses: actions/checkout@v2
@@ -46,6 +46,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9  // Mypy doens't yet work with python 3.10
+          - 3.9  # Mypy doens't yet work with python 3.10
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,18 @@ black = ">=19.10b0"
 flake8 = ">=3.8.2"
 flake8-annotations = ">=2.0.1"
 isort = ">=4.3.21"
-coverage = {extras = ["toml"], version = ">=5.0.4"}
+coverage = { extras = ["toml"], version = ">=5.0.4" }
 pytest-cov = ">=.8.1"
 codecov = ">=2.0.22"
-mypy = "^0.812"
+mypy = { version = "^0.812", python = "< 3.10" }  # mypy isn't yet working for python 3.10
 pydantic = "^1.7.3"
 mkdocs = "^1.2.2"
 mkdocs-material = "^7.2.6"
 
 [tool.isort]
-include_trailing_comma=true
-line_length=88
-use_parentheses=true
+include_trailing_comma = true
+line_length = 88
+use_parentheses = true
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/test/test_locker.py
+++ b/test/test_locker.py
@@ -42,7 +42,7 @@ def test_locker_with_wrong_data(locker: Locker) -> None:
 @patch("builtins.input", lambda *args: "y")
 def test_locker_without_file_accepted(locker: Locker) -> None:
     io_mocker = mock_open()
-    with patch("io.open", io_mocker):
+    with patch.object(Path, "open", io_mocker):
         value = "File has different context"
         locker.lock(value)
         write_calls = [call for call in io_mocker.mock_calls if call[0] == "().write"]


### PR DESCRIPTION
The issue seems to be that `patch("io.open", io_mocker)` doesn't catch the writing of the lock file as it does on `<= Python3.9`, the expected file is (instead) written to the file system during testing. 

This might be a hard one to catch using mocking in a cross-version way.

Maybe use the filesystem instead...